### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/bvweerd/geekmagic-tv-esp8266/security/code-scanning/1](https://github.com/bvweerd/geekmagic-tv-esp8266/security/code-scanning/1)

In general, the fix is to explicitly set `permissions:` for the workflow or the specific job so that the automatically-provided `GITHUB_TOKEN` has only the minimal required access. For this workflow, the job only needs to read repository contents (for `actions/checkout`) and does not need to write to the repo, issues, or pull requests. Artifact upload does not require additional token scopes. Therefore, we can set `permissions: contents: read` for the `build` job.

The best minimal change without altering functionality is to add a `permissions:` block under the `build` job definition in `.github/workflows/manual-build.yml`. Specifically, between `runs-on: ubuntu-latest` (line 14) and `steps:` (line 16), add:

```yaml
    permissions:
      contents: read
```

No other steps, actions, or configuration need to change, and no imports or external libraries are involved since this is a YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
