### PR TITLE
Add GPIO button for page toggling and backlight control

### DIFF
--- a/src/button.cpp
+++ b/src/button.cpp
@@ -1,0 +1,62 @@
+#include "button.h"
+#include "config.h"
+#include "logger.h"
+
+// Button state tracking
+static bool lastButtonState = HIGH;
+static bool currentButtonState = HIGH;
+static unsigned long buttonPressStartTime = 0;
+static unsigned long lastDebounceTime = 0;
+static bool buttonPressed = false;
+
+void buttonInit() {
+    pinMode(PIN_BUTTON, INPUT_PULLUP);
+    lastButtonState = digitalRead(PIN_BUTTON);
+    currentButtonState = lastButtonState;
+    logPrintf("Button initialized on GPIO%d (INPUT_PULLUP)", PIN_BUTTON);
+}
+
+ButtonPress buttonUpdate() {
+    // Read current button state (LOW when pressed with pullup)
+    bool reading = digitalRead(PIN_BUTTON);
+
+    // Check if button state changed (for debouncing)
+    if (reading != lastButtonState) {
+        lastDebounceTime = millis();
+    }
+
+    // Debounce: only accept state change after debounce time
+    if ((millis() - lastDebounceTime) > BUTTON_DEBOUNCE_MS) {
+        // If the button state has changed after debounce
+        if (reading != currentButtonState) {
+            currentButtonState = reading;
+
+            // Button was just pressed (HIGH -> LOW with pullup)
+            if (currentButtonState == LOW && !buttonPressed) {
+                buttonPressStartTime = millis();
+                buttonPressed = true;
+                logPrint("Button pressed");
+            }
+            // Button was just released (LOW -> HIGH with pullup)
+            else if (currentButtonState == HIGH && buttonPressed) {
+                unsigned long pressDuration = millis() - buttonPressStartTime;
+                buttonPressed = false;
+
+                logPrintf("Button released after %lu ms", pressDuration);
+
+                // Determine press type
+                if (pressDuration >= BUTTON_LONG_PRESS_MIN_MS) {
+                    logPrint("Long press detected");
+                    return BUTTON_LONG;
+                } else if (pressDuration <= BUTTON_SHORT_PRESS_MAX_MS) {
+                    logPrint("Short press detected");
+                    return BUTTON_SHORT;
+                }
+                // Between short and long threshold - ignore
+            }
+        }
+    }
+
+    lastButtonState = reading;
+    return BUTTON_NONE;
+}

--- a/src/button.h
+++ b/src/button.h
@@ -1,0 +1,20 @@
+#ifndef BUTTON_H
+#define BUTTON_H
+
+#include <Arduino.h>
+
+// Button press types
+enum ButtonPress {
+    BUTTON_NONE = 0,
+    BUTTON_SHORT = 1,
+    BUTTON_LONG = 2
+};
+
+// Initialize button GPIO and state
+void buttonInit();
+
+// Update button state (call in main loop)
+// Returns BUTTON_NONE, BUTTON_SHORT, or BUTTON_LONG
+ButtonPress buttonUpdate();
+
+#endif

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,7 @@
 
 // Pin definitions
 #define PIN_BACKLIGHT 5
+#define PIN_BUTTON 4
 
 // Display settings
 #define DISPLAY_WIDTH 240
@@ -31,6 +32,11 @@
 // Update intervals
 #define SCROLL_INTERVAL 30
 #define DISPLAY_UPDATE_INTERVAL 1000
+
+// Button settings
+#define BUTTON_DEBOUNCE_MS 50
+#define BUTTON_SHORT_PRESS_MAX_MS 800
+#define BUTTON_LONG_PRESS_MIN_MS 2000
 
 // Filesystem
 #define IMAGE_DIR "/image/"

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -511,3 +511,48 @@ void displayShowAPScreen(const char* ssid, const char* password, const char* ip)
     displayState.ipInfo[sizeof(displayState.ipInfo) - 1] = '\0'; // Ensure null-termination
     displayUpdate();
 }
+
+void displayCycleNextPage() {
+    // Don't cycle pages if in AP mode
+    if (displayState.apMode) {
+        logPrint(F("Page cycling disabled in AP mode"));
+        return;
+    }
+
+    // Cycle: Clock -> Image (if available) -> Clock
+    if (!displayState.showImage) {
+        // Currently showing clock, try to switch to image if available
+        if (displayState.imagePath[0] != '\0' && LittleFS.exists(displayState.imagePath)) {
+            logPrint(F("Cycling to image page"));
+            displayState.showImage = true;
+        } else {
+            logPrint(F("No image available, staying on clock page"));
+        }
+    } else {
+        // Currently showing image, switch back to clock
+        logPrint(F("Cycling to clock page"));
+        displayState.showImage = false;
+    }
+
+    // Immediately update the display
+    displayUpdate();
+}
+
+// Track backlight state for toggle functionality
+static int savedBrightness = 100;
+static bool backlightOn = true;
+
+void displayToggleBacklight() {
+    if (backlightOn) {
+        // Turn off backlight
+        logPrint(F("Backlight OFF"));
+        savedBrightness = 100; // Assume current brightness is 100 (could be read from settings)
+        displaySetBrightness(0);
+        backlightOn = false;
+    } else {
+        // Turn on backlight
+        logPrintf("Backlight ON (brightness: %d)", savedBrightness);
+        displaySetBrightness(savedBrightness);
+        backlightOn = true;
+    }
+}

--- a/src/display.h
+++ b/src/display.h
@@ -40,6 +40,8 @@ void displayRenderImage(const char *path);
 void displayShowMessage(const String &msg);
 void displayShowAPScreen(const char* ssid, const char* password, const char* ip);
 void displayBlankScreen();
+void displayCycleNextPage();
+void displayToggleBacklight();
 
 extern DisplayState displayState;
 extern TFT_eSPI tft;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "webserver.h"
 #include "settings.h"
 #include "logger.h"
+#include "button.h"
 
 // NTP server (for NTPClient)
 #define NTP_SERVER "pool.ntp.org"
@@ -582,7 +583,7 @@ void setup() {
 
     displaySetBrightness(100);  // Full brightness for testing
 
-
+    buttonInit();  // Initialize GPIO button
 
     displayShowMessage(F("SmartClock\nInitializing..."));
 
@@ -755,6 +756,14 @@ void loop() {
     // Monitor WiFi connection and handle failsafe mode
 
     monitorWiFi();
+
+    // Handle button presses
+    ButtonPress buttonPress = buttonUpdate();
+    if (buttonPress == BUTTON_SHORT) {
+        displayCycleNextPage();
+    } else if (buttonPress == BUTTON_LONG) {
+        displayToggleBacklight();
+    }
 
     // Only handle OTA and mDNS if not in failsafe mode
     if (!wifiFailsafeMode) {


### PR DESCRIPTION
Implemented custom button functionality on GPIO4:
- Short press (≤800ms): Cycle between clock and image pages
- Long press (≥2000ms): Toggle backlight on/off

Changes:
- Created button.h/cpp module with debouncing and press detection
- Added displayCycleNextPage() to cycle through display modes
- Added displayToggleBacklight() to toggle backlight state
- Integrated button handling into main loop
- Added PIN_BUTTON configuration to config.h
- Button uses INPUT_PULLUP mode (active low)

Resolves #8