### PR TITLE
Fix WiFi connection to wait for IP address assignment

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,18 @@ bool tryConnectWiFi(int maxAttempts) {
             yield();
         }
 
+                // Wait for IP address to be assigned after WiFi connection
                 if (WiFi.status() == WL_CONNECTED) {
+                    Serial.println(F("WiFi associated, waiting for IP..."));
+                    unsigned long ipWaitStart = millis();
+                    while (WiFi.localIP() == IPAddress(0,0,0,0) &&
+                           millis() - ipWaitStart < 10000) { // Wait up to 10 seconds for IP
+                        delay(100);
+                        yield();
+                    }
+                }
+
+                if (WiFi.status() == WL_CONNECTED && WiFi.localIP() != IPAddress(0,0,0,0)) {
 
                     Serial.println(F("WiFi connected!"));
 


### PR DESCRIPTION
The device was reporting as "connected" after WiFi association but before receiving an IP address via DHCP. This caused the device to appear on the router without an IP, and connection attempts would fail after 5 retries.

Changes:
- Added explicit wait loop for IP address assignment (up to 10 seconds)
- Modified connection check to verify both WiFi.status() and valid IP
- Added debug message "WiFi associated, waiting for IP..."

This ensures the device won't report as connected until DHCP completes and a valid IP address is assigned.

Fixes issue where device shows on router without IP address.