### PR TITLE
Enable smooth image swapping without screen flashing

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -449,8 +449,8 @@ void displayRenderImage(const char *path) {
     }
     logPrint(String(F("INFO: Image file opened: ")) + path);
 
-    tft.fillScreen(TFT_BLACK);
-
+    // Direct image swap without clearing screen for smooth transitions
+    // The new JPEG will overwrite the previous image directly
     JRESULT res = TJpgDec.drawFsJpg(0, 0, jpgFile);
     if (res != JDR_OK) {
         String errorMsg = String(F("JPEG Decode Failed\nCode: ")) + String(res);


### PR DESCRIPTION
Removed the tft.fillScreen(TFT_BLACK) call from displayRenderImage() to allow new images to directly overwrite the previous image. This eliminates the distracting black flash during image transitions, matching the smooth behavior of the official firmware.

Image-to-image transitions now stay in the same display mode (mode 2) so displayUpdate() won't clear the screen either, resulting in seamless image swapping.